### PR TITLE
Fix for proxy handling, added python 3.8 support, changes in indantation for resulting PKGBUILD

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-build-tools-py3
 	pkgdesc = Utilities for building Arch packages for ROS stacks.
 	pkgver = 0.3.1
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/ros-melodic-arch/ros-build-tools-py3
 	arch = any
 	license = BSD
@@ -18,7 +18,7 @@ pkgbase = ros-build-tools-py3
 	source = create_pkgbuild.py
 	sha256sums = 5528486d640d91136276edda2075aefc06f360e6297e556051bae57b9479aeda
 	sha256sums = 9626b8e5f3865f5640660f4a7f6a00afc4db8448b95329b4d5a64bd691677a88
-	sha256sums = 6171500f4e807e170f3705277032107b3902502a7fcccf8ab5b300a35580ebf7
+	sha256sums = 66ed7e8fbbbd9b000960fdd38b949ee796c8ca22c30997156abc4ced5f4e6be7
 
 pkgname = ros-build-tools-py3
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-build-tools-py3
 	pkgdesc = Utilities for building Arch packages for ROS stacks.
 	pkgver = 0.3.1
-	pkgrel = 3
+	pkgrel = 4
 	url = https://github.com/ros-melodic-arch/ros-build-tools-py3
 	arch = any
 	license = BSD
@@ -18,7 +18,7 @@ pkgbase = ros-build-tools-py3
 	source = create_pkgbuild.py
 	sha256sums = 5528486d640d91136276edda2075aefc06f360e6297e556051bae57b9479aeda
 	sha256sums = 9626b8e5f3865f5640660f4a7f6a00afc4db8448b95329b4d5a64bd691677a88
-	sha256sums = 66ed7e8fbbbd9b000960fdd38b949ee796c8ca22c30997156abc4ced5f4e6be7
+	sha256sums = ecb2d98688dd2888999e45c709f6aa03f0d04e8cd3b44390012fd798a520bff7
 
 pkgname = ros-build-tools-py3
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url="https://github.com/ros-melodic-arch/ros-build-tools-py3"
 pkgname='ros-build-tools-py3'
 pkgver='0.3.1'
 arch=('any')
-pkgrel=2
+pkgrel=3
 license=('BSD')
 makedepends=()
 optdepends=('python3' 'python-argparse' 'python-yaml' 'python-termcolor' 'python-certifi')
@@ -22,7 +22,7 @@ source=('fix-python-scripts.sh'
 
 sha256sums=('5528486d640d91136276edda2075aefc06f360e6297e556051bae57b9479aeda'
 	    '9626b8e5f3865f5640660f4a7f6a00afc4db8448b95329b4d5a64bd691677a88'
-	    '6171500f4e807e170f3705277032107b3902502a7fcccf8ab5b300a35580ebf7')
+	    '66ed7e8fbbbd9b000960fdd38b949ee796c8ca22c30997156abc4ced5f4e6be7')
 build() {
   return 0
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url="https://github.com/ros-melodic-arch/ros-build-tools-py3"
 pkgname='ros-build-tools-py3'
 pkgver='0.3.1'
 arch=('any')
-pkgrel=3
+pkgrel=4
 license=('BSD')
 makedepends=()
 optdepends=('python3' 'python-argparse' 'python-yaml' 'python-termcolor' 'python-certifi')
@@ -22,7 +22,7 @@ source=('fix-python-scripts.sh'
 
 sha256sums=('5528486d640d91136276edda2075aefc06f360e6297e556051bae57b9479aeda'
 	    '9626b8e5f3865f5640660f4a7f6a00afc4db8448b95329b4d5a64bd691677a88'
-	    '66ed7e8fbbbd9b000960fdd38b949ee796c8ca22c30997156abc4ced5f4e6be7')
+	    'ecb2d98688dd2888999e45c709f6aa03f0d04e8cd3b44390012fd798a520bff7')
 build() {
   return 0
 }

--- a/create_pkgbuild.py
+++ b/create_pkgbuild.py
@@ -353,7 +353,7 @@ make DESTDIR="${pkgdir}/" install
             'tarball_url': "%s/archive/release/%s/%s/${pkgver}.tar.gz"
                            % (self.repository_url.replace('.git', ''),
                               self.distro.name, self.name),
-            'tarball_dir': "%s-release-%s-%s"#'tarball_dir': "%s-release-%s-%s-${pkgver}"
+            'tarball_dir': "%s-release-%s-%s"
                            % (self.repository_name, self.distro.name, self.name),
             'tarball_sha': self._download_tarball(self.tarball_url, output_dir,
                                                   "ros-%s-%s" % (self.distro.name,

--- a/create_pkgbuild.py
+++ b/create_pkgbuild.py
@@ -30,21 +30,6 @@ updated_packages_filename = os.path.join(updates_packages_dir,
 makepkg_filename = os.path.join(updates_packages_dir,
                                 "makepkg_%(distro)s.dump")
 
-#http = urllib3.PoolManager()
-
-#try:
-#    import certifi
-#
-#    # Make verified HTTPS requests
-#    http = urllib3.PoolManager(
-#        cert_reqs='CERT_REQUIRED',  # Force certificate check.
-#        ca_certs=certifi.where(),  # Path to the Certifi bundle.
-#    )
-#except ImportError as e:
-#    # HTTPS requests will not be verified
-#    pass
-
-
 class PackageBase(object):
 
     def __init__(self, distro, repository_url, name, version):
@@ -112,7 +97,6 @@ class PackageBase(object):
     Arguments:
     - `url`: Valid URL pointing to a package.xml file.
     """
-        #return catkin_pkg.package.parse_package_string(http.request('GET', url).data)
         try:
             response = requests.get(url)
             # If the response was successful, no Exception will be raised
@@ -205,8 +189,6 @@ class PackageBase(object):
     def _get_rosdep_dictionary(self, rosdep_urls):
         dependency_map = {}
         for rosdep_url in rosdep_urls:
-            #stream = http.request('GET', rosdep_url).data
-            #rosdep_file = yaml.load(stream, Loader=yaml.BaseLoader)
             try:
                 response = requests.get(rosdep_url, stream=True)
                 # If the response was successful, no Exception will be raised
@@ -235,10 +217,6 @@ class PackageBase(object):
     clashes.
     """
         tarball_path = "%s/%s-%s" % (path, name, url.split('/')[-1])
-        #if not os.path.exists(tarball_path):
-        #    with http.request('GET', url, preload_content=False) \
-        #            as r, open(tarball_path, 'wb') as out_file:
-        #        shutil.copyfileobj(r, out_file)
         if not os.path.exists(tarball_path):
             try:
                 with requests.get(url, stream=True) as r:
@@ -361,7 +339,7 @@ make DESTDIR="${pkgdir}/" install
         if python_version_major == "3":
             # If Python 3.4: PySideConfig{.cpython-34m}.cmake
             python_basename = ".cpython-%s" % (python_version_full.replace(".", ""))
-        
+
         pkgbuild = self.BUILD_TEMPLATE % {
             'distro': self.distro.name,
             'arch_package_name': self._rosify_package_name(self.name),
@@ -375,7 +353,7 @@ make DESTDIR="${pkgdir}/" install
             'tarball_url': "%s/archive/release/%s/%s/${pkgver}.tar.gz"
                            % (self.repository_url.replace('.git', ''),
                               self.distro.name, self.name),
-            'tarball_dir': "%s-release-%s-%s"                  #'tarball_dir': "%s-release-%s-%s-${pkgver}"
+            'tarball_dir': "%s-release-%s-%s"#'tarball_dir': "%s-release-%s-%s-${pkgver}"
                            % (self.repository_name, self.distro.name, self.name),
             'tarball_sha': self._download_tarball(self.tarball_url, output_dir,
                                                   "ros-%s-%s" % (self.distro.name,
@@ -426,7 +404,6 @@ class MetaPackage(PackageBase):
     def __init__(self, distro, repository_url, name, version):
         try:
             super(MetaPackage, self).__init__(distro, repository_url, name, version)
-        #except urllib3.exceptions.HTTPError:
         except HTTPError:
             # Virtual metapackage
             # TODO: there should be a cleaner way to deal with this...

--- a/create_pkgbuild.py
+++ b/create_pkgbuild.py
@@ -279,57 +279,59 @@ class PackageBase(object):
 
 class Package(PackageBase):
     BUILD_TEMPLATE = """# Script generated with create_pkgbuild.py
-    # For more information: https://github.com/ros-melodic-arch/ros-build-tools-py3
-    pkgdesc="ROS - %(description)s"
-    url='%(site_url)s'
+# For more information: https://github.com/ros-melodic-arch/ros-build-tools-py3
+pkgdesc="ROS - %(description)s"
+url='%(site_url)s'
 
-    pkgname='ros-%(distro)s-%(arch_package_name)s'
-    pkgver='%(package_version)s'
-    arch=('any')
-    pkgrel=%(package_release)s
-    license=('%(license)s')
+pkgname='ros-%(distro)s-%(arch_package_name)s'
+pkgver='%(package_version)s'
+arch=('any')
+pkgrel=%(package_release)s
+license=('%(license)s')
 
-    ros_makedepends=(%(ros_build_dependencies)s)
-    makedepends=('cmake' 'ros-build-tools'
-    ${ros_makedepends[@]}
-    %(other_build_dependencies)s)
+ros_makedepends=(%(ros_build_dependencies)s)
+makedepends=('cmake' 'ros-build-tools'
+  ${ros_makedepends[@]}
+  %(other_build_dependencies)s)
 
-    ros_depends=(%(ros_run_dependencies)s)
-    depends=(${ros_depends[@]}
-    %(other_run_dependencies)s)
-    _dir=%(tarball_dir)s
-    source=(""${pkgname}-${pkgver}.tar.gz""::""%(tarball_url)s"")
-    sha256sums=('%(tarball_sha)s')
-    build() {
-        # Use ROS environment variables
-        source /usr/share/ros-build-tools/clear-ros-env.sh
-        [ -f /opt/ros/%(distro)s/setup.bash ] && source /opt/ros/%(distro)s/setup.bash
+ros_depends=(%(ros_run_dependencies)s)
+depends=(${ros_depends[@]}
+  %(other_run_dependencies)s)
 
-        # Create build directory
-        [ -d ${srcdir}/build ] || mkdir ${srcdir}/build
-        cd ${srcdir}/build
+_dir=%(tarball_dir)s
+source=("${pkgname}-${pkgver}.tar.gz"::"%(tarball_url)s")
+sha256sums=('%(tarball_sha)s')
 
-        # Fix Python2/Python3 conflicts
-        /usr/share/ros-build-tools/fix-python-scripts.sh -v %(python_version_major)s ${srcdir}/${_dir}
+build() {
+    # Use ROS environment variables
+    source /usr/share/ros-build-tools/clear-ros-env.sh
+    [ -f /opt/ros/%(distro)s/setup.bash ] && source /opt/ros/%(distro)s/setup.bash
 
-        # Build project
-        cmake ${srcdir}/${_dir} \\
-                -DCMAKE_BUILD_TYPE=Release \\
-                -DCATKIN_BUILD_BINARY_PACKAGE=%(binary)s \\
-                -DCMAKE_INSTALL_PREFIX=/opt/ros/%(distro)s \\
-                -DPYTHON_EXECUTABLE=%(python_executable)s \\
-                -DPYTHON_INCLUDE_DIR=%(python_include_dir)s \\
-                -DPYTHON_LIBRARY=%(python_library)s \\
-                -DPYTHON_BASENAME=%(python_basename)s \\
-                -DSETUPTOOLS_DEB_LAYOUT=OFF
+    # Create build directory
+    [ -d ${srcdir}/build ] || mkdir ${srcdir}/build
+    cd ${srcdir}/build
+
+    # Fix Python2/Python3 conflicts
+    /usr/share/ros-build-tools/fix-python-scripts.sh -v %(python_version_major)s ${srcdir}/${_dir}
+
+    # Build project
+    cmake ${srcdir}/${_dir} \\
+            -DCMAKE_BUILD_TYPE=Release \\
+            -DCATKIN_BUILD_BINARY_PACKAGE=%(binary)s \\
+            -DCMAKE_INSTALL_PREFIX=/opt/ros/%(distro)s \\
+            -DPYTHON_EXECUTABLE=%(python_executable)s \\
+            -DPYTHON_INCLUDE_DIR=%(python_include_dir)s \\
+            -DPYTHON_LIBRARY=%(python_library)s \\
+            -DPYTHON_BASENAME=%(python_basename)s \\
+            -DSETUPTOOLS_DEB_LAYOUT=OFF
     make
-    }
+}
 
-    package() {
-    cd "${srcdir}/build"
-    make DESTDIR="${pkgdir}/" install
-    }
-    """
+package() {
+cd "${srcdir}/build"
+make DESTDIR="${pkgdir}/" install
+}
+"""
 
     def generate(self, python_version, exclude_dependencies=[], rosdep_urls=[],
                  output_dir=None):


### PR DESCRIPTION
### proxy issue
When using `create_pkgbuild.py` I ran into problems working behind a proxy.
The used library for https handling (`urllib3`) needs in code specification of a proxy as mentioned in the documentation: [https://urllib3.readthedocs.io/en/latest/reference/](https://urllib3.readthedocs.io/en/latest/reference/)
or is shown here: [https://stackoverflow.com/questions/31151615/how-to-handle-proxies-in-urllib3](https://stackoverflow.com/questions/31151615/how-to-handle-proxies-in-urllib3).
A [ProxyManager](https://urllib3.readthedocs.io/en/latest/#proxymanager) is needed in `urllib3`.
Instead I use [Python Request](https://requests.readthedocs.io/en/master/) , because it works with bash proxy variables (e.g. `export http_proxy="http://myproxy:port; https_proxy=...`).
At the moment `urllib3` is still in the code for url parsing (see l.591 in `create_pkgbuild.py`).

### added Python 3.8 support
These includes slight modifications in 2 arrays

### Indentation in PKGBUILD
created PKGBUILD scripts with no extra indentation. I think these came along through better readability of the python source.  

### changes for tarball dir
See in line 356, just spare out the package version in tarball dir, leads to problems in all of my created packages. Is there maybe a new convention for ros git projects?

Thank you 

Resolves #4 